### PR TITLE
Add abs-rel mode and BTN_TOUCH notification.

### DIFF
--- a/drivers/input/input_pinnacle.c
+++ b/drivers/input/input_pinnacle.c
@@ -21,7 +21,11 @@ static int pinnacle_write(const struct device *dev, const uint8_t addr, const ui
     return config->write(dev, addr, val);
 }
 
-#define NUM_ZIDLE  0x05
+// Now that we are counting ZIDLEs it would be very bad to miss one.  But in my testing I see that happen (rarely - once every
+// couple of days of usage).  The fact that the current irq system is edge triggered probably isn't great for this reason.
+// But for now just have the touch controller emit NUM_ZIDLE_PAD extra idles
+#define NUM_ZIDLE  3
+#define NUM_ZIDLE_PAD 2
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 
@@ -597,7 +601,7 @@ static int pinnacle_init(const struct device *dev) {
         return ret;
     }
     k_msleep(20);
-    ret = pinnacle_write(dev, PINNACLE_Z_IDLE, NUM_ZIDLE); 
+    ret = pinnacle_write(dev, PINNACLE_Z_IDLE, NUM_ZIDLE + NUM_ZIDLE_PAD);
     if (ret < 0) {
         LOG_ERR("can't write %d", ret);
         return ret;

--- a/drivers/input/input_pinnacle.c
+++ b/drivers/input/input_pinnacle.c
@@ -21,6 +21,8 @@ static int pinnacle_write(const struct device *dev, const uint8_t addr, const ui
     return config->write(dev, addr, val);
 }
 
+#define NUM_ZIDLE  0x05
+
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 
 static int pinnacle_i2c_seq_read(const struct device *dev, const uint8_t addr, uint8_t *buf,
@@ -229,41 +231,72 @@ static int pinnacle_era_write(const struct device *dev, const uint16_t addr, uin
     return ret;
 }
 
-static void pinnacle_report_data_abs(const struct device *dev) {
+static void pinnacle_send_rel(const struct device *dev, int8_t dx, int8_t dy) {
     const struct pinnacle_config *config = dev->config;
-    uint8_t packet[6];
-    int ret;
-    ret = pinnacle_seq_read(dev, PINNACLE_STATUS1, packet, 1);
-    if (ret < 0) {
-        LOG_ERR("read status: %d", ret);
-        return;
-    }
-    if (!(packet[0] & PINNACLE_STATUS1_SW_DR)) {
-        return;
-    }
-    ret = pinnacle_seq_read(dev, PINNACLE_2_2_PACKET0, packet, 6);
-    if (ret < 0) {
-        LOG_ERR("read packet: %d", ret);
-        return;
-    }
     struct pinnacle_data *data = dev->data;
-    // TODO: Enable SW3-SW5 as well
-    uint8_t btn = packet[0] &
-                  (PINNACLE_PACKET0_BTN_PRIM | PINNACLE_PACKET0_BTN_SEC | PINNACLE_PACKET0_BTN_AUX);
-    uint8_t x_low = packet[2];
-    uint8_t y_low = packet[3];
-    uint8_t xy_high = packet[4];
-    int16_t x = ((xy_high & 0x0F) << 8) | x_low;
-    int16_t y = ((xy_high & 0xF0) << 4) | y_low;
-    int8_t z = (uint8_t)(packet[5] & 0x1F);
 
-    LOG_DBG("button: %d, x: %d y: %d z: %d", btn, x, y, z);
-    if (data->in_int) {
-        LOG_DBG("Clearing status bit");
-        ret = pinnacle_clear_status(dev);
-        data->in_int = true;
+    pinnacle_clear_status(dev);
+
+    bool must_send = false;
+
+    uint8_t btn = data->last_btn;
+    if (!config->no_taps && (btn || data->btn_cache)) {
+        for (int i = 0; i < 3; i++) {
+            uint8_t btn_val = btn & BIT(i);
+            if (btn_val != (data->btn_cache & BIT(i))) {
+                input_report_key(dev, INPUT_BTN_0 + i, btn_val ? 1 : 0, false, K_FOREVER);
+                must_send = true;
+            }
+        }
     }
 
+    data->btn_cache = btn;
+    bool is_touching = (data->last_z > 0);
+    bool touch_changed = false;
+    if(is_touching) {
+        must_send = true;
+
+        if(data->num_z_idle > 0) { // we just recently had z idles
+            touch_changed = true;
+            data->num_z_idle = 0;
+            dx = 0;
+            dy = 0; // starting a new press, must reset deltas
+        }
+    } else {
+        data->num_z_idle++;
+        if(data->num_z_idle == NUM_ZIDLE) {
+            touch_changed = true;
+        }
+        dx = 0;
+        dy = 0;
+    }
+
+    LOG_DBG("Rel move: touch_changed=%d z=%d dx=%d dy=%d", touch_changed, data->last_z, dx, dy);
+
+    if(touch_changed)
+    {
+        // Finalize the input event only if we have something to report
+        input_report_key(dev, INPUT_BTN_TOUCH, is_touching ? 1 : 0, false, K_FOREVER);
+        must_send = true;
+    }
+
+    if(must_send) {
+        input_report_rel(dev, INPUT_REL_X, dx, false, K_FOREVER);
+        input_report_rel(dev, INPUT_REL_Y, dy, true, K_FOREVER); 
+    }
+}
+
+static void pinnacle_send_abs(const struct device *dev) {
+    const struct pinnacle_config *config = dev->config;
+    struct pinnacle_data *data = dev->data;
+    int16_t x = data->last_x;
+    int16_t y = data->last_y;
+    int8_t z = data->last_z;
+
+    LOG_DBG("Clearing status bit");
+    pinnacle_clear_status(dev);
+
+    uint8_t btn = data->last_btn;
     if (!config->no_taps && (btn || data->btn_cache)) {
         for (int i = 0; i < 3; i++) {
             uint8_t btn_val = btn & BIT(i);
@@ -274,6 +307,7 @@ static void pinnacle_report_data_abs(const struct device *dev) {
     }
 
     data->btn_cache = btn;
+
     if (z > 0) {
         if (x < config->absolute_mode_clamp_min_x) {
             x = config->absolute_mode_clamp_min_x;
@@ -293,10 +327,68 @@ static void pinnacle_report_data_abs(const struct device *dev) {
         input_report_abs(dev, INPUT_ABS_X, x, false, K_FOREVER);
         input_report_abs(dev, INPUT_ABS_Y, y, true, K_FOREVER);
     }
+
+    return;
+}
+
+static int pinnacle_read_abs(const struct device *dev) {
+    uint8_t packet[6];
+    int ret;
+    ret = pinnacle_seq_read(dev, PINNACLE_STATUS1, packet, 1);
+    if (ret < 0) {
+        LOG_ERR("read status: %d", ret);
+        return ret;
+    }
+    if (!(packet[0] & PINNACLE_STATUS1_SW_DR)) {
+        return -1;
+    }
+    ret = pinnacle_seq_read(dev, PINNACLE_2_2_PACKET0, packet, 6);
+    if (ret < 0) {
+        LOG_ERR("read packet: %d", ret);
+        return ret;
+    }
+    struct pinnacle_data *data = dev->data;
+    // TODO: Enable SW3-SW5 as well
+    data->last_btn = packet[0] &
+                  (PINNACLE_PACKET0_BTN_PRIM | PINNACLE_PACKET0_BTN_SEC | PINNACLE_PACKET0_BTN_AUX);
+    uint8_t x_low = packet[2];
+    uint8_t y_low = packet[3];
+    uint8_t xy_high = packet[4];
+    data->last_x = ((xy_high & 0x0F) << 8) | x_low;
+    data->last_y = ((xy_high & 0xF0) << 4) | y_low;
+    data->last_z = (uint8_t)(packet[5] & 0x1F);
+
+    LOG_DBG("button: %d, x: %d y: %d z: %d", data->last_btn, data->last_x, data->last_y, data->last_z);
+    return 0;
+}
+
+static void pinnacle_report_data_abs(const struct device *dev) {
+    int ret = pinnacle_read_abs(dev);
+    if (ret == 0) {
+        pinnacle_send_abs(dev);
+    }
+}
+
+static void pinnacle_report_data_abs_rel(const struct device *dev) {
+    struct pinnacle_data *data = dev->data;
+    int16_t old_x = data->last_x;
+    int16_t old_y = data->last_y;
+
+    int ret = pinnacle_read_abs(dev);
+
+    if (ret == 0) {
+        int16_t dx = data->last_x - old_x;
+        int16_t dy = data->last_y - old_y;
+        const struct pinnacle_config *config = dev->config;
+
+        dx /= config->abs_rel_divisor;
+        dy /= config->abs_rel_divisor;
+
+        pinnacle_send_rel(dev, (int8_t) dx, (int8_t) dy);
+    }
 }
 
 static void pinnacle_report_data_rel(const struct device *dev) {
-    const struct pinnacle_config *config = dev->config;
     uint8_t packet[3];
     int ret;
     ret = pinnacle_seq_read(dev, PINNACLE_STATUS1, packet, 1);
@@ -320,7 +412,7 @@ static void pinnacle_report_data_rel(const struct device *dev) {
     LOG_HEXDUMP_DBG(packet, 3, "Pinnacle Packets");
 
     struct pinnacle_data *data = dev->data;
-    uint8_t btn = packet[0] &
+    data->last_btn = packet[0] &
                   (PINNACLE_PACKET0_BTN_PRIM | PINNACLE_PACKET0_BTN_SEC | PINNACLE_PACKET0_BTN_AUX);
 
     int8_t dx = (int8_t)packet[1];
@@ -333,27 +425,9 @@ static void pinnacle_report_data_rel(const struct device *dev) {
         WRITE_BIT(dy, 7, 1);
     }
 
-    if (data->in_int) {
-        LOG_DBG("Clearing status bit");
-        ret = pinnacle_clear_status(dev);
-        data->in_int = true;
-    }
-
-    if (!config->no_taps && (btn || data->btn_cache)) {
-        for (int i = 0; i < 3; i++) {
-            uint8_t btn_val = btn & BIT(i);
-            if (btn_val != (data->btn_cache & BIT(i))) {
-                input_report_key(dev, INPUT_BTN_0 + i, btn_val ? 1 : 0, false, K_FOREVER);
-            }
-        }
-    }
-
-    data->btn_cache = btn;
-
-    input_report_rel(dev, INPUT_REL_X, dx, false, K_FOREVER);
-    input_report_rel(dev, INPUT_REL_Y, dy, true, K_FOREVER);
-
-    return;
+    // always claim touch changed
+    data->last_z = 1;
+    pinnacle_send_rel(dev, (int8_t) dx, (int8_t) dy);
 }
 
 static void pinnacle_work_cb(struct k_work *work) {
@@ -363,6 +437,8 @@ static void pinnacle_work_cb(struct k_work *work) {
 
     if (config->absolute_mode) {
         pinnacle_report_data_abs(dev);
+    } else if (config->abs_rel_divisor) {
+        pinnacle_report_data_abs_rel(dev);
     } else {
         pinnacle_report_data_rel(dev);
     }
@@ -521,7 +597,7 @@ static int pinnacle_init(const struct device *dev) {
         return ret;
     }
     k_msleep(20);
-    ret = pinnacle_write(dev, PINNACLE_Z_IDLE, 0x05); // No Z-Idle packets
+    ret = pinnacle_write(dev, PINNACLE_Z_IDLE, NUM_ZIDLE); 
     if (ret < 0) {
         LOG_ERR("can't write %d", ret);
         return ret;
@@ -581,7 +657,7 @@ static int pinnacle_init(const struct device *dev) {
         return ret;
     }
     uint8_t feed_cfg1 = PINNACLE_FEED_CFG1_EN_FEED;
-    if (config->absolute_mode) {
+    if (config->absolute_mode || config->abs_rel_divisor) {
         feed_cfg1 |= PINNACLE_FEED_CFG1_ABS_MODE;
         LOG_ERR("Using absolute mode");
     } else {
@@ -656,6 +732,7 @@ static int pinnacle_pm_action(const struct device *dev, enum pm_device_action ac
         .no_taps = DT_INST_PROP(n, no_taps),                                                       \
         .no_secondary_tap = DT_INST_PROP(n, no_secondary_tap),                                     \
         .absolute_mode = DT_INST_PROP(n, absolute_mode),                                           \
+        .abs_rel_divisor = DT_INST_PROP(n, abs_rel_divisor),                                       \
         .absolute_mode_scale_to_width = DT_INST_PROP(n, absolute_mode_scale_to_width),             \
         .absolute_mode_scale_to_height = DT_INST_PROP(n, absolute_mode_scale_to_height),           \
         .absolute_mode_clamp_min_x = DT_INST_PROP(n, absolute_mode_clamp_min_x),                   \

--- a/drivers/input/input_pinnacle.h
+++ b/drivers/input/input_pinnacle.h
@@ -75,7 +75,6 @@
 struct pinnacle_data {
     uint8_t btn_cache; // the prior button reading
     uint8_t last_btn; // the current button reading
-    bool in_int;
     int8_t last_z;
     int8_t num_z_idle;
     int16_t last_x, last_y; // last abs reading

--- a/drivers/input/input_pinnacle.h
+++ b/drivers/input/input_pinnacle.h
@@ -73,8 +73,13 @@
 #define PINNACLE_PACKET0_Y_SIGN BIT(5)   // Y delta sign
 
 struct pinnacle_data {
-    uint8_t btn_cache;
+    uint8_t btn_cache; // the prior button reading
+    uint8_t last_btn; // the current button reading
     bool in_int;
+    int8_t last_z;
+    int8_t num_z_idle;
+    int16_t last_x, last_y; // last abs reading
+
     const struct device *dev;
     struct gpio_callback gpio_cb;
     struct k_work work;
@@ -101,6 +106,7 @@ struct pinnacle_config {
     pinnacle_write_t write;
 
     bool rotate_90, sleep_en, no_taps, no_secondary_tap, x_invert, y_invert, absolute_mode;
+    uint8_t abs_rel_divisor;
     enum pinnacle_sensitivity sensitivity;
     uint8_t x_axis_z_min, y_axis_z_min;
     uint16_t absolute_mode_scale_to_width, absolute_mode_scale_to_height, absolute_mode_clamp_min_x, absolute_mode_clamp_max_x, absolute_mode_clamp_min_y, absolute_mode_clamp_max_y;

--- a/drivers/input/input_pinnacle.h
+++ b/drivers/input/input_pinnacle.h
@@ -100,9 +100,10 @@ struct pinnacle_config {
     pinnacle_seq_read_t seq_read;
     pinnacle_write_t write;
 
-    bool rotate_90, sleep_en, no_taps, no_secondary_tap, x_invert, y_invert;
+    bool rotate_90, sleep_en, no_taps, no_secondary_tap, x_invert, y_invert, absolute_mode;
     enum pinnacle_sensitivity sensitivity;
     uint8_t x_axis_z_min, y_axis_z_min;
+    uint16_t absolute_mode_scale_to_width, absolute_mode_scale_to_height, absolute_mode_clamp_min_x, absolute_mode_clamp_max_x, absolute_mode_clamp_min_y, absolute_mode_clamp_max_y;
     const struct gpio_dt_spec dr;
 };
 

--- a/dts/bindings/input/cirque,pinnacle-common.yaml
+++ b/dts/bindings/input/cirque,pinnacle-common.yaml
@@ -30,6 +30,10 @@ properties:
     default: 4
   absolute-mode:
     type: boolean
+  abs-rel-divisor:
+    type: int
+    description: If non zero, uses pad in absmode, but sends relative events (and touch press/release)
+    default: 0
   absolute-mode-scale-to-width:
     type: int
     default: 1024

--- a/dts/bindings/input/cirque,pinnacle-common.yaml
+++ b/dts/bindings/input/cirque,pinnacle-common.yaml
@@ -28,4 +28,38 @@ properties:
   y-axis-z-min:
     type: int
     default: 4
+  absolute-mode:
+    type: boolean
+  absolute-mode-scale-to-width:
+    type: int
+    default: 1024
+    description: Scale reported x values to [0-1024]
+  absolute-mode-scale-to-height:
+    type: int
+    default: 1024
+    description: Scale reported y values to [0-1024]
+  absolute-mode-clamp-min-x:
+    type: int
+    default: 128
+    description: |
+      Specification says that active reporting of absolute position
+      is: 128 ≤ X ≤1920 and 64 ≤ Y ≤ 1472, but on my touchpad, I need other values.
+  absolute-mode-clamp-max-x:
+    type: int
+    default: 1920
+    description: |
+      Specification says that active reporting of absolute position
+      is: 128 ≤ X ≤1920 and 64 ≤ Y ≤ 1472, but on my touchpad, I need other values.
+  absolute-mode-clamp-min-y:
+    type: int
+    default: 64
+    description: |
+      Specification says that active reporting of absolute position
+      is: 128 ≤ X ≤1920 and 64 ≤ Y ≤ 1472, but on my touchpad, I need other values.
+  absolute-mode-clamp-max-y:
+    type: int
+    default: 1472
+    description: |
+      Specification says that active reporting of absolute position
+      is: 128 ≤ X ≤1920 and 64 ≤ Y ≤ 1472, but on my touchpad, I need other values.
 


### PR DESCRIPTION
Hi,

Thanks for making this slick driver.  I just used it on my recently purchased Beekeeb Toucan.  One issue I noticed is that I wanted a way to get touch notifications.  With touch notification I was able to add a layer that instantly turns on/off anytime a finger is touching the trackpad.  This allows adding an input processor to switch layers to a layer that remaps some keys to be mouse buttons.

As I'm sure you know - to get touch data (z height) from the pinnacle part the chip needs to be in abs mode.  So when this mode is enabled via the device-tree I use the @halfdane existing abs work (included as a dependency for my change) to configure the part.  But I do my own math to convert the abs coords into relative moves before forwarding up the stack.

I don't know if you want this as a PR, but if you do here it is.  If you have interest I'm happily willing to update the PR to match whatever requirements your project has.

Rock on. 

---
    This mode operates the chip in absolute mode (with all of the existing
    absolute options).  But reports events as RELATIVE.  This allows use as a
    relative touchpad but the addition of EVENT_BTN_TOUCH notifications when
    a finger is either on or off of the touchpad.
    
    Such notifications are especially useful to automate instantly switching to/from
    a layer that has keys bounds as 'mouse buttons'. (with none of the lag/delays of
    'temporary layers' or the cost of constantly sending bluetooth packets between
    two halves of a split keybaord)
