### PR TITLE
add shutdown support to cirque (to save lots of power in deep sleep)

### DIFF
--- a/drivers/input/input_pinnacle.h
+++ b/drivers/input/input_pinnacle.h
@@ -19,6 +19,7 @@
 #define PINNACLE_SYS_CFG 0x03 // Contains system operation and configuration bits.
 #define PINNACLE_SYS_CFG_EN_SLEEP_BIT 2
 #define PINNACLE_SYS_CFG_EN_SLEEP BIT(2)
+#define PINNACLE_SYS_CFG_SHUTDOWN_BIT 1
 #define PINNACLE_SYS_CFG_SHUTDOWN BIT(1)
 #define PINNACLE_SYS_CFG_RESET BIT(0)
 
@@ -107,3 +108,4 @@ struct pinnacle_config {
 };
 
 int pinnacle_set_sleep(const struct device *dev, bool enabled);
+int pinnacle_set_shutdown(const struct device *dev, bool enabled);


### PR DESCRIPTION
This change adds support for setting the pinnacle shutdown bit before entering zmk deep-sleep.  According to the datasheet this transitions the part from a typical 1.7mA to 0.23uA (about 5000x savings).  I haven't measured with a meter (currently at a small one-room rental in Taipei), but after running for a few days on my keyboard that seems about right.

Btw: I also briefly tried turning on your sleep support.  And I found (what I guess you also found based on your existing open PR attempt to work-around) - that pro grammatically exiting sleep doesn't seem to work.  Does that match your experience as well?  I guess this chip is just a bit buggy? ;-)  alas, such is life.

Kevin